### PR TITLE
Outputting compiled JS to dist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ node_modules
 typings
 .swagger-codegen-ignore
 .vscode/*
+dist

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
         "postinstall": "typings install",
         "clean": "rm -Rf node_modules/ typings/ *.js",
         "build": "tsc",
-        "test": "npm run build && node client.js"
+        "test": "npm run build && node dist/client.js"
     },
     "author": "Swagger Codegen Contributors",
     "license": "Unlicense",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
         "removeComments": true,
         "sourceMap": true,
         "noLib": false,
-        "declaration": true
+        "declaration": true,
+        "outDir": "dist"
     },
     "exclude": [
         "node_modules",
@@ -16,4 +17,3 @@
         "typings/browser.d.ts"
     ]
 }
-


### PR DESCRIPTION
So that compiled JS & Typescript map files don't pollute the top-level directory